### PR TITLE
Eslint stylistic migration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,10 +5,9 @@ module.exports = {
 		es2021: true,
 		node: false,
 	},
-	extends: [
-		'eslint:recommended',
-		'plugin:@typescript-eslint/recommended',
-		'plugin:@typescript-eslint/recommended-requiring-type-checking',
+	plugins: [
+		'@stylistic',
+		'@typescript-eslint',
 	],
 	parser: '@typescript-eslint/parser',
 	parserOptions: {
@@ -21,8 +20,10 @@ module.exports = {
 			'./scripts/tsconfig.json',
 		],
 	},
-	plugins: [
-		'@typescript-eslint',
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:@typescript-eslint/recommended-requiring-type-checking',
 	],
 	ignorePatterns: [
 		'*.md',
@@ -105,36 +106,68 @@ module.exports = {
 			}
 		],
 
+		///////////////////////////////
+		// TypeScript-specific rules //
+		///////////////////////////////
+		'@typescript-eslint/consistent-type-assertions': [
+			'error',
+			{
+				assertionStyle: 'as',
+			},
+		],
+		'@typescript-eslint/explicit-module-boundary-types': [
+			'error'
+		],
+		
 		////////////////
 		// Code style //
 		////////////////
-		'array-bracket-spacing': [
+		'curly': [
+			'error',
+			'all',
+		],
+		'default-case-last': 'error',
+		'no-var': 'error',
+		'one-var': [
 			'error',
 			'never',
 		],
-		'arrow-parens': [
+
+		'@stylistic/array-bracket-newline': [
+			'error',
+			'consistent',
+		],
+		'@stylistic/array-bracket-spacing': [
+			'error',
+			'never',
+		],
+		'@stylistic/array-element-newline': [
+			'error',
+			'consistent',
+		],
+		'@stylistic/arrow-parens': [
 			'error',
 			'always',
 		],
-		'arrow-spacing': [
+		'@stylistic/arrow-spacing': [
 			'error',
 			{
 				before: true,
 				after: true,
 			},
 		],
-		'block-spacing': [
+		'@stylistic/block-spacing': [
 			'error',
 			'always',
 		],
-		'brace-style': [
+		'@stylistic/brace-style': [
 			'error',
 			'1tbs',
 			{
 				allowSingleLine: true,
 			},
 		],
-		'comma-dangle': [
+		'@stylistic/comma-dangle': [
 			'error',
 			{
 				arrays: 'always-multiline',
@@ -144,82 +177,121 @@ module.exports = {
 				functions: 'only-multiline',
 			},
 		],
-		'comma-spacing': [
+		'@stylistic/comma-spacing': [
 			'error',
 			{
 				before: false,
 				after: true,
 			}
 		],
-		'comma-style': [
+		'@stylistic/comma-style': [
 			'error',
 			'last',
 		],
-		'curly': [
-			'error',
-			'all',
-		],
-		'default-case-last': 'error',
-		'eol-last': [
+		'@stylistic/eol-last': [
 			'error',
 			'always',
 		],
-		'func-call-spacing': [
+		'@stylistic/func-call-spacing': [
 			'error',
 			'never',
 		],
-		'indent': [
+		'@stylistic/function-call-argument-newline': [
+			'error',
+			'consistent',
+		],
+		'@stylistic/function-paren-newline': [
+			'error',
+			'multiline-arguments',
+		],
+		'@stylistic/indent': [
 			'error',
 			'tab',
 			{
 				SwitchCase: 1,
 				ignoredNodes: [
 					// Ignore indentation within template literals to allow them to be indented like markup
-					"TemplateLiteral *",
+					'TemplateLiteral *',
+					// This rule doesn't behave correctly for TypeScript generic types
+					// https://github.com/typescript-eslint/typescript-eslint/issues/455#issuecomment-560585408
+					'TSTypeParameterInstantiation ',
 				],
 			},
 		],
-		// My IDE handles this, it's annoying to see the squigly lines appear
-		'no-trailing-spaces': [
-			'off',
-		],
-		'no-var': 'error',
-		'one-var': [
+		'@stylistic/key-spacing': [
 			'error',
-			'never',
+			{
+				'beforeColon': false,
+				'afterColon': true,
+				mode: 'minimum',
+			},
 		],
-		'quotes': [
+		'@stylistic/keyword-spacing': [
+			'error',
+			{
+				'before': true,
+				'after': true,
+			},
+		],
+		'@stylistic/multiline-ternary': [
+			'error',
+			'always-multiline',
+		],
+		'@stylistic/new-parens': [
+			'error',
+			'always',
+		],
+		'@stylistic/no-extra-semi': [
+			'error',
+		],
+		'@stylistic/no-mixed-spaces-and-tabs': [
+			'error',
+			'smart-tabs',
+		],
+		'@stylistic/no-trailing-spaces': [
+			'error',
+		],
+		'@stylistic/no-whitespace-before-property': [
+			'error',
+		],
+		'@stylistic/object-curly-newline': [
+			'error',
+			{
+				multiline: true,
+				consistent: true,
+			},
+		],
+		'@stylistic/quotes': [
 			'error',
 			'single',
 			{
 				allowTemplateLiterals: true,
 			},
 		],
-		'rest-spread-spacing': [
+		'@stylistic/rest-spread-spacing': [
 			'error',
 			'never',
 		],
-		'semi': [
+		'@stylistic/semi': [
 			'error',
 			'always',
 		],
-		'semi-spacing': [
+		'@stylistic/semi-spacing': [
 			'error',
 			{
 				before: false,
 				after: true,
 			},
 		],
-		'semi-style': [
+		'@stylistic/semi-style': [
 			'error',
 			'last',
 		],
-		'space-before-blocks': [
+		'@stylistic/space-before-blocks': [
 			'error',
 			'always',
 		],
-		'space-before-function-paren': 'off',
-		'@typescript-eslint/space-before-function-paren': [
+		'@stylistic/space-before-function-paren': [
 			'error',
 			{
 				anonymous: 'always',
@@ -227,17 +299,17 @@ module.exports = {
 				asyncArrow: 'always',
 			},
 		],
-		'space-in-parens': [
+		'@stylistic/space-in-parens': [
 			'error',
 			'never',
 		],
-		'space-unary-ops': [
+		'@stylistic/space-unary-ops': [
 			'error',
 			{
 				words: true,
 			},
 		],
-		'spaced-comment': [
+		'@stylistic/spaced-comment': [
 			'error',
 			'always',
 			{
@@ -249,16 +321,40 @@ module.exports = {
 				},
 			},
 		],
-		'no-mixed-spaces-and-tabs': [
-			'error',
-			'smart-tabs',
-		],
-
-		// TypeScript-specific rules
-		'@typescript-eslint/consistent-type-assertions': [
+		'@stylistic/switch-colon-spacing': [
 			'error',
 			{
-				assertionStyle: 'as',
+				'after': true,
+				'before': false,
+			},
+		],
+
+		// TypeScript-specific code style rules
+		'@stylistic/member-delimiter-style': [
+			'error',
+			{
+				multiline: {
+					delimiter: 'semi',
+					requireLast: true,
+				},
+				singleline: {
+					delimiter: 'semi',
+					requireLast: true,
+				},
+				multilineDetection: 'brackets',
+			},
+		],
+		'@stylistic/type-annotation-spacing': [
+			'error',
+			{
+				before: false,
+				after: true,
+				overrides: {
+					arrow: {
+						before: true,
+						after: true,
+					},
+				},
 			},
 		],
 	}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .env
 *.sublime-workspace
+src/coverage/
 docs/assets/css/
 docs/assets/js/dist/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules/
 .env
-*.sublime-workspace
+*.tgz
 src/coverage/
 docs/assets/css/
 docs/assets/js/dist/

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Usually, you will just want to run `npm start`, but this project also provides t
 * `npm start` runs both the `server` and `watch` tasks simultaneously.
 
 * `npm test` runs any configured test suites using [Jest](https://jestjs.io/).
-
+* `npm run testCoverage` runs any configured test suites using [Jest](https://jestjs.io/), and reports coverage information.
 * `npm run testWatch` runs any configured test suites using [Jest](https://jestjs.io/) in watch mode.
 
 ### .env
@@ -199,6 +199,8 @@ These dependencies are used when working on the project locally.
 	* [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin): Allows `eslint` to lint TypeScript
 
 	* [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser): Allows `eslint` to parse TypeScript
+
+	* [@stylistic/eslint-plugin](https://eslint.style/): Provides linting rules to enforce code style
 
 * [stylelint](https://www.npmjs.com/package/stylelint): Linting CSS
 

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
 	],
 	"types": "dist/main-export.d.ts",
 	"scripts": {
-		"server": "ts-node --esm scripts/server.ts",
+		"server": "node --loader ts-node/esm scripts/server.ts",
 
-		"buildJs": "concurrently \"tsc --noEmit\" \"ts-node --esm scripts/build.ts\"",
+		"buildJs": "concurrently \"tsc --noEmit\" \"node --loader ts-node/esm scripts/build.ts\"",
 		"buildCss": "sass docs/assets/scss:docs/assets/css",
 		"build": "concurrently \"npm run buildJs\" \"npm run buildCss\"",
 
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+		"testCoverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --collectCoverage",
 
-		"watchJs": "ts-node --esm scripts/build-watch.ts",
+		"watchJs": "node --loader ts-node/esm scripts/build-watch.ts",
 		"watchCss": "sass docs/assets/scss:docs/assets/css --watch",
 		"testWatch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
 		"watch": "concurrently --kill-others \"rimraf ./dist && tsc --watch --preserveWatchOutput --noEmit\" \"npm run watchJs\" \"npm run watchCss\" \"npm run testWatch\"",
@@ -38,6 +39,7 @@
 	"license": "Hippocratic-2.1",
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",
+		"@stylistic/eslint-plugin": "^1.0.0",
 		"@testing-library/jest-dom": "^6.1.4",
 		"@testing-library/user-event": "^14.5.1",
 		"@types/express": "^4.17.20",
@@ -61,6 +63,6 @@
 		"typescript": "^5.2.2"
 	},
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	}
 }


### PR DESCRIPTION
This PR primarily migrates code style eslint rules to use the [@stylistic](https://eslint.style/) plugin.

It also makes a few other miscellaneous changes, such as updating to use Node v20 and adding a test coverage script.