### PR TITLE
Added separate tsconfig for tests so they can be linted

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
 		tsConfigRootDir: __dirname,
 		project: [
 			'./tsconfig.json',
+			'./tsconfig.test.json',
 			'./docs/tsconfig.json',
 			'./scripts/tsconfig.json',
 		],
@@ -118,7 +119,7 @@ module.exports = {
 		'@typescript-eslint/explicit-module-boundary-types': [
 			'error'
 		],
-		
+
 		////////////////
 		// Code style //
 		////////////////

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,44 @@
+{
+	"include": [
+		"src/**/__tests__/**/*",
+		"src/**/*.test.*",
+		"src/**/*.spec.*"
+	],
+	"compilerOptions": {
+		// Fixes some issues with non-ESM imports
+		// https://www.typescriptlang.org/tsconfig#esModuleInterop
+		"esModuleInterop": true,
+		// Skip type-checking declaration files, to improve performance
+		// https://www.typescriptlang.org/tsconfig#skipLibCheck
+		"skipLibCheck": true,
+		// Always target the latest supported ECMAScript version
+		// https://www.typescriptlang.org/tsconfig#target
+		"target": "ESNext",
+		// Standardises how type and non-type imports are treated
+		// https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax
+		"verbatimModuleSyntax": true,
+		// Tell TypeScript every file is a module, so it doesn't have to figure it out
+		// https://www.typescriptlang.org/tsconfig#moduleDetection
+		"moduleDetection": "force",
+
+		// Strict mode should really be a default
+		// https://www.typescriptlang.org/tsconfig#strict
+		"strict": true,
+
+		// Use Node module resolution, since this code is run using `ts-node`
+		// https://www.typescriptlang.org/tsconfig#moduleResolution
+		"moduleResolution": "NodeNext",
+		// This must be set to "NodeNext" when "moduleResolution" is set to "NodeNext"
+		// https://www.typescriptlang.org/tsconfig#module
+		// https://www.typescriptlang.org/docs/handbook/modules/reference.html#summary-1
+		"module": "NodeNext",
+		// This code is not compiled using `tsc`
+		// https://www.typescriptlang.org/tsconfig#noEmit
+		"noEmit": true,
+
+		// Include types for the latest ECMAScript features,
+		// excluding DOM APIs so it can run directly in Node
+		// https://www.typescriptlang.org/tsconfig#lib
+		"lib": ["ESNext"],
+	}
+}


### PR DESCRIPTION
Because tests are excluded from the main `tsconfig.json`, and eslint is configured to include files based on configured TypeScript projects, test files can't be linted.

This PR adds a new `tsconfig.test.json` to cover test files, and includes it in the configured list of projects for eslint.